### PR TITLE
[MRG] Fix bug with comma in title

### DIFF
--- a/src/templates/person.js
+++ b/src/templates/person.js
@@ -3,15 +3,15 @@ import Helmet from 'react-helmet'
 
 export default class PersonalAboutTemplate extends React.Component {
     render(){
-      console.log("PersonalAboutTemplate props", this.props)
       //Note that if 2 people have the exact same name this will fail
       const currentPerson = this.props.data.allPeopleJson.edges[0].node;
       console.log("current person", currentPerson);
 
+      const title_text = `About ${currentPerson.name}`;
       return (
         <div>
           <Helmet>
-            <title>About {currentPerson.name}</title>
+            <title>{title_text}</title>
           </Helmet>
           <h1>
             About {currentPerson.name}


### PR DESCRIPTION
Workaround for bug in react-helmet https://github.com/nfl/react-helmet/issues/286 that places a comma into the title unless you construct the title text ahead of time.

Closes #63 